### PR TITLE
Fix --canvas-color for Obsidian 1.13+

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -102,9 +102,9 @@ body {
   --text: 76, 79, 105;
   --subtext1: 92, 95, 119;
   --subtext0: 108, 111, 133;
-  --overlay2: 76, 79, 105;
+  --overlay2: rgb(76, 79, 105);
   --overlay1: 140, 143, 161;
-  --overlay0: 156, 160, 176;
+  --overlay0: rgb(156, 160, 176);
   --surface2: 221, 225, 238;
   --surface1: 188, 192, 204;
   --surface0: 221, 225, 238;
@@ -115,13 +115,13 @@ body {
 .theme-light.ivory-light,
 .theme-light.lily-light {
   --subtext1: 97, 92, 132;
-  --overlay2: 86, 100, 122;
+  --overlay2: rgb(86, 100, 122);
   --overlay1: 152, 147, 165;
   --subtext0: 108, 111, 133;
   --text: 86, 100, 122;
 }
 .theme-light.lily-light {
-  --overlay0: 161, 156, 173;
+  --overlay0: rgb(161, 156, 173);
   --surface2: 241, 183, 153;
   --surface1: 203, 194, 186;
   --surface0: 242, 194, 163;
@@ -130,7 +130,7 @@ body {
   --base: 245, 219, 195;
 }
 .theme-light.ivory-light {
-  --overlay0: 231, 215, 198;
+  --overlay0: rgb(231, 215, 198);
   --surface2: 231, 215, 198;
   --surface1: 209, 201, 194;
   --surface0: 233, 204, 176;
@@ -142,9 +142,9 @@ body {
   --text: 86, 100, 122;
   --subtext1: 92, 95, 119;
   --subtext0: 108, 111, 133;
-  --overlay2: 76, 79, 105;
+  --overlay2: rgb(76, 79, 105);
   --overlay1: 140, 143, 161;
-  --overlay0: 156, 160, 176;
+  --overlay0: rgb(156, 160, 176);
   --surface2: 221, 225, 238;
   --surface1: 188, 192, 204;
   --surface0: 224, 240, 255;
@@ -156,9 +156,9 @@ body {
   --text: 86, 100, 122;
   --subtext1: 97, 92, 132;
   --subtext0: 0, 0, 0;
-  --overlay2: 86, 100, 122;
+  --overlay2: rgb(86, 100, 122);
   --overlay1: 152, 147, 165;
-  --overlay0: 166, 172, 146;
+  --overlay0: rgb(166, 172, 146);
   --surface2: 166, 172, 146;
   --surface1: 209, 201, 194;
   --surface0: 210, 213, 200;
@@ -202,9 +202,9 @@ body {
   --text: 198, 206, 239;
   --subtext1: 181, 189, 220;
   --subtext0: 165, 172, 201;
-  --overlay2: 148, 155, 183;
+  --overlay2: rgb(148, 155, 183);
   --overlay1: 131, 138, 164;
-  --overlay0: 115, 120, 145;
+  --overlay0: rgb(115, 120, 145);
   --surface2: 98, 103, 126;
   --surface1: 81, 86, 108;
   --surface0: 65, 69, 89;
@@ -216,9 +216,9 @@ body {
   --text: 197, 207, 245;
   --subtext1: 179, 188, 224;
   --subtext0: 161, 170, 203;
-  --overlay2: 143, 151, 183;
+  --overlay2: rgb(143, 151, 183);
   --overlay1: 125, 132, 162;
-  --overlay0: 108, 114, 141;
+  --overlay0: rgb(108, 114, 141);
   --surface2: 90, 95, 120;
   --surface1: 72, 76, 100;
   --surface0: 54, 58, 79;
@@ -230,9 +230,9 @@ body {
   --text: 198, 208, 245;
   --subtext1: 179, 188, 223;
   --subtext0: 161, 168, 201;
-  --overlay2: 142, 149, 179;
+  --overlay2: rgb(142, 149, 179);
   --overlay1: 123, 129, 157;
-  --overlay0: 105, 109, 134;
+  --overlay0: rgb(105, 109, 134);
   --surface2: 86, 89, 112;
   --surface1: 67, 70, 90;
   --surface0: 49, 50, 68;
@@ -244,9 +244,9 @@ body {
   --text: 217, 224, 238;
   --subtext1: 211, 205, 214;
   --subtext0: 190, 179, 193;
-  --overlay2: 167, 156, 176;
+  --overlay2: rgb(167, 156, 176);
   --overlay1: 152, 139, 162;
-  --overlay0: 109, 107, 125;
+  --overlay0: rgb(109, 107, 125);
   --surface2: 87, 82, 105;
   --surface1: 45, 40, 72;
   --surface0: 48, 45, 65;
@@ -402,7 +402,7 @@ body {
   color-scheme: light;
   --background-modifier-border: rgb(var(--surface1));
   --background-modifier-border-hover: rgb(var(--surface2));
-  --background-modifier-border-focus: rgb(var(--overlay0));
+  --background-modifier-border-focus: var(--overlay0);
   --cards-background-modifier-border: rgb(var(--surface1));
   --shib-speech-bubble-opacity: var(--shib-sp-op-light, 0.5);
   --background-modifier-cover: #00000022;
@@ -485,9 +485,9 @@ body {
   --color-base-25: rgb(var(--surface0));
   --color-base-30: rgb(var(--surface1));
   --color-base-35: rgb(var(--surface2));
-  --color-base-40: rgb(var(--overlay0));
+  --color-base-40: var(--overlay0);
   --color-base-50: rgb(var(--overlay1));
-  --color-base-60: rgb(var(--overlay2));
+  --color-base-60: var(--overlay2);
   --color-base-70: rgb(var(--subtext0));
   --color-base-100: rgb(var(--text));
   --input-shadow: inset 0 0.5px 0.5px 0.5px rgba(var(--text), 0.09),
@@ -526,7 +526,7 @@ body {
   --background-modifier-message: rgba(var(--exterior), 0.9);
   --modal-border-color: rgb(var(--surface0));
   --text-normal: rgb(var(--text));
-  --text-muted: rgb(var(--overlay2));
+  --text-muted: var(--overlay2);
   --text-muted-rgb: var(--overlay2);
   --text-faint: rgb(var(--subtext0));
   --text-error: rgb(var(--red));


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--canvas-color` (and `--canvas-color-1` through `--canvas-color-6`) works. It now provides a valid CSS color value (e.g. `#e93147`) instead of a bare RGB triplet (`233, 49, 71`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--canvas-color-1: 255, 0, 128;
/* After */
--canvas-color-1: rgb(255, 0, 128);
```

**2. Wrapping `var(--canvas-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--canvas-color), 0.1);
/* After */
background: color-mix(in srgb, var(--canvas-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--canvas-color` / `--canvas-color-N` declarations with `rgb()`
- Replaced `rgb(var(--canvas-color))` with `var(--canvas-color)`
- Replaced `rgba(var(--canvas-color), <alpha>)` with `color-mix(in srgb, var(--canvas-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
